### PR TITLE
Use IO.gets instead of Kernel.gets

### DIFF
--- a/lib/cased/cli/interactive_session.rb
+++ b/lib/cased/cli/interactive_session.rb
@@ -57,7 +57,7 @@ module Cased
 
       def reason_prompt
         print Cased::CLI::Log.string 'Please enter a reason for access: '
-        session.reason = gets.chomp
+        session.reason = STDIN.gets.chomp
       end
 
       def wait_for_approval


### PR DESCRIPTION
IO.gets:

> Reads the next “line'' from the I/O stream; lines are separated by sep.

Kernel.gets:

> Returns (and assigns to $_) the next line from the list of files in ARGV (or $*), or from standard input if no files are present on the command line.

We don't want different behaviors for receiving input depending on presence of ARGV or not, just to get user input.