### PR TITLE
Re-authenticate with Cased when settings change

### DIFF
--- a/lib/cased/cli/interactive_session.rb
+++ b/lib/cased/cli/interactive_session.rb
@@ -46,6 +46,13 @@ module Cased
 
         if session.create
           handle_state(session.state)
+        elsif session.reauthenticate?
+          Cased::CLI::Log.log "You must re-authenticate with Cased due to recent changes to this application's settings."
+
+          identity = Cased::CLI::Identity.new
+          session.authentication.token = identity.identify
+
+          create
         elsif session.unauthorized?
           if session.authentication.exists?
             Cased::CLI::Log.log "Existing credentials at #{session.authentication.credentials_path} are not valid."

--- a/lib/cased/cli/session.rb
+++ b/lib/cased/cli/session.rb
@@ -194,6 +194,10 @@ module Cased
         error == :unauthorized
       end
 
+      def reauthenticate?
+        error == :reauthenticate
+      end
+
       def record_output?
         guard_application.dig('settings', 'record_output') || false
       end
@@ -233,6 +237,8 @@ module Cased
             @error = :reason_required
           when 'unauthorized'
             @error = :unauthorized
+          when 'reauthenticate'
+            @error = :reauthenticate
           else
             @error = true
             return false


### PR DESCRIPTION
Here is an example of using the new `reauthenticate` error type to prompt the user to re-authenticate with Cased.

```
Running via Spring preloader in process 23876
[cased] Running under Cased CLI.
[cased] Please enter a reason for access: My reason
[cased] You must re-authenticate with Cased due to recent changes to this application's settings.
[cased] To login, please visit:
http://localhost:3000/g0b470ee55b47048f32785eb04ba3bb
[cased] CLI session has been approved
Loading development environment (Rails 6.1.3)
irb(main):001:0> exit

```