### PR TITLE
Forward user's IP address to CLI session

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ end
 
 authentication = Cased::CLI::Authentication.new
 identity = Cased::CLI::Identity.new
-authentication.token = identity.identify
+token, ip_address = identity.identify
+authentication.token = token
 
 session = Cased::CLI::Session.new(
   authentication: authentication,

--- a/lib/cased/cli/identity.rb
+++ b/lib/cased/cli/identity.rb
@@ -28,9 +28,12 @@ module Cased
         while user_id.nil?
           count += 1
           response = Cased.clients.cli.get(poll_url)
-          user_id = response.body.dig('user', 'id')
-          ip_address = response.body.fetch('ip_address')
-          sleep 1 if user_id.nil?
+          if response.success?
+            user_id = response.body.dig('user', 'id')
+            ip_address = response.body.fetch('ip_address')
+          else
+            sleep 1
+          end
         end
 
         [user_id, ip_address]

--- a/lib/cased/cli/identity.rb
+++ b/lib/cased/cli/identity.rb
@@ -23,15 +23,17 @@ module Cased
       def poll(poll_url)
         count = 0
         user_id = nil
+        ip_address = nil
 
         while user_id.nil?
           count += 1
           response = Cased.clients.cli.get(poll_url)
           user_id = response.body.dig('user', 'id')
+          ip_address = response.body.fetch('ip_address')
           sleep 1 if user_id.nil?
         end
 
-        user_id
+        [user_id, ip_address]
       end
     end
   end

--- a/lib/cased/cli/interactive_session.rb
+++ b/lib/cased/cli/interactive_session.rb
@@ -50,7 +50,9 @@ module Cased
           Cased::CLI::Log.log "You must re-authenticate with Cased due to recent changes to this application's settings."
 
           identity = Cased::CLI::Identity.new
-          session.authentication.token = identity.identify
+          token, ip_address = identity.identify
+          session.authentication.token = token
+          session.forwarded_ip_address = ip_address
 
           create
         elsif session.unauthorized?
@@ -61,7 +63,9 @@ module Cased
           end
 
           identity = Cased::CLI::Identity.new
-          session.authentication.token = identity.identify
+          token, ip_address = identity.identify
+          session.authentication.token = token
+          session.forwarded_ip_address = ip_address
 
           create
         elsif session.reason_required?

--- a/lib/cased/cli/session.rb
+++ b/lib/cased/cli/session.rb
@@ -92,7 +92,7 @@ module Cased
       # @example
       #   session.forwarded_ip_address #=> "1.1.1.1"
       # @return [String, nil]
-      attr_reader :forwarded_ip_address
+      attr_accessor :forwarded_ip_address
 
       # Public: The client's IP V4 or IP V6 address that initiated the CLI session.
       # @example

--- a/lib/cased/cli/session.rb
+++ b/lib/cased/cli/session.rb
@@ -86,9 +86,17 @@ module Cased
       # @return [String, nil]
       attr_accessor :reason
 
+      # Public: The forwarded IP V4 or IP V6 address of the user that initiated
+      # the CLI session.
+      #
+      # @example
+      #   session.forwarded_ip_address #=> "1.1.1.1"
+      # @return [String, nil]
+      attr_reader :forwarded_ip_address
+
       # Public: The client's IP V4 or IP V6 address that initiated the CLI session.
       # @example
-      #   session.reason #=> "1.1.1.1"
+      #   session.ip_address #=> "1.1.1.1"
       # @return [String, nil]
       attr_reader :ip_address
 
@@ -144,6 +152,7 @@ module Cased
         @command = session.fetch('command')
         @metadata = session.fetch('metadata')
         @reason = session.fetch('reason')
+        @forwarded_ip_address = session.fetch('forwarded_ip_address')
         @ip_address = session.fetch('ip_address')
         @requester = session.fetch('requester')
         @responded_at = session['responded_at']
@@ -226,6 +235,7 @@ module Cased
 
         response = Cased.clients.cli.post('cli/sessions',
           user_token: authentication.token,
+          forwarded_ip_address: forwarded_ip_address,
           reason: reason,
           metadata: metadata,
           command: command)

--- a/test/lib/cased/cli/identity_test.rb
+++ b/test/lib/cased/cli/identity_test.rb
@@ -24,6 +24,7 @@ module Cased
           .to_return(
             status: 200,
             body: {
+              ip_address: '127.0.0.1',
               user: {
                 id: 'user_1234',
               },
@@ -34,8 +35,10 @@ module Cased
           )
 
         identify = Cased::CLI::Identity.new
+        token, ip_address = identify.identify
 
-        assert_equal 'user_1234', identify.identify
+        assert_equal 'user_1234', token
+        assert_equal '127.0.0.1', ip_address
       end
 
       def test_identify_is_unauthorized

--- a/test/lib/cased/cli/session_test.rb
+++ b/test/lib/cased/cli/session_test.rb
@@ -18,7 +18,8 @@ module Cased
               url: 'https://app.cased.com/cli/sessions/guard_session_1234',
               state: 'requested',
               reason: '',
-              ip_address: '127.0.0.1',
+              ip_address: '1.1.1.1',
+              forwarded_ip_address: '127.0.0.1',
               command: 'irb',
               metadata: {},
               requester: {
@@ -258,7 +259,8 @@ module Cased
               url: 'https://app.cased.com/cli/sessions/guard_session_1234',
               state: 'requested',
               reason: '',
-              ip_address: '127.0.0.1',
+              ip_address: '1.1.1.1',
+              forwarded_ip_address: '127.0.0.1',
               command: 'irb',
               metadata: {},
               requester: {
@@ -349,7 +351,8 @@ module Cased
               url: 'https://app.cased.com/cli/sessions/guard_session_1234',
               state: 'requested',
               reason: 'My reason',
-              ip_address: '127.0.0.1',
+              ip_address: '1.1.1.1',
+              forwarded_ip_address: '127.0.0.1',
               command: 'irb',
               metadata: {
                 user_agent: 'iPhone',
@@ -374,7 +377,8 @@ module Cased
         assert_equal 'https://app.cased.com/cli/sessions/guard_session_1234', session.url
         assert_equal 'requested', session.state
         assert_equal 'My reason', session.reason
-        assert_equal '127.0.0.1', session.ip_address
+        assert_equal '1.1.1.1', session.ip_address
+        assert_equal '127.0.0.1', session.forwarded_ip_address
         assert_equal 'irb', session.command
         assert_equal 'iPhone', session.metadata['user_agent']
         assert_equal 'user_1234', session.requester['id']
@@ -397,7 +401,8 @@ module Cased
               url: 'https://app.cased.com/cli/sessions/guard_session_1234',
               state: 'canceled',
               reason: 'My reason',
-              ip_address: '127.0.0.1',
+              ip_address: '1.1.1.1',
+              forwarded_ip_address: '127.0.0.1',
               command: 'irb',
               metadata: {
                 user_agent: 'iPhone',
@@ -442,7 +447,8 @@ module Cased
               url: 'https://app.cased.com/cli/sessions/guard_session_1234',
               state: 'canceled',
               reason: 'My reason',
-              ip_address: '127.0.0.1',
+              ip_address: '1.1.1.1',
+              forwarded_ip_address: '127.0.0.1',
               command: 'irb',
               metadata: {
                 user_agent: 'iPhone',
@@ -479,7 +485,8 @@ module Cased
               url: 'https://app.cased.com/cli/sessions/guard_session_1234',
               state: 'canceled',
               reason: 'My reason',
-              ip_address: '127.0.0.1',
+              ip_address: '1.1.1.1',
+              forwarded_ip_address: '127.0.0.1',
               command: 'irb',
               metadata: {
                 user_agent: 'iPhone',


### PR DESCRIPTION
This PR preserves the user's forwarded IP address when creating the CLI session. Previously only the client IP address which when initiated on remote servers would not properly indicate where the user is operating the session from.