### PR TITLE
Exit interactive session on timeout

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,19 +28,3 @@ jobs:
       - name: Run Tests
         run: |
           bundle exec rake test
-
-      - name: Generate yard documentation
-        run: |
-          bundle exec yard
-
-      - name: Upload test coverage report
-        uses: actions/upload-artifact@v2
-        with:
-          name: coverage
-          path: coverage/**/*
-
-      - name: Upload generated yard documentation
-        uses: actions/upload-artifact@v2
-        with:
-          name: yard
-          path: doc/**/*

--- a/lib/cased/cli/interactive_session.rb
+++ b/lib/cased/cli/interactive_session.rb
@@ -112,8 +112,10 @@ module Cased
           exit 1
         when 'timed_out'
           Cased::CLI::Log.log 'CLI session has timed out'
+          exit 1
         when 'canceled'
           Cased::CLI::Log.log 'CLI session has been canceled'
+          exit 0
         end
       end
     end

--- a/test/lib/cased/cli/interactive_session_test.rb
+++ b/test/lib/cased/cli/interactive_session_test.rb
@@ -70,10 +70,10 @@ module Cased
         begin
           Cased::CLI::InteractiveSession.start
           assert false, 'did not expect this to be reached'
-        rescue SystemExit => error
+        rescue SystemExit => e
           assert true
-          assert_equal 1, error.status
-          assert_not error.success?
+          assert_equal 1, e.status
+          assert_not e.success?
         end
       ensure
         Cased.config.guard_user_token = old_guard_user_token

--- a/test/lib/cased/cli/interactive_session_test.rb
+++ b/test/lib/cased/cli/interactive_session_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'active_support/testing/assertions'
+
+module Cased
+  module CLI
+    class InteractiveSessionTest < Cased::Test
+      include ActiveSupport::Testing::Assertions
+
+      def test_interactive_session
+        old_guard_user_token = Cased.config.guard_user_token
+        Cased.config.guard_user_token = 'user_1234'
+
+        stub_request(:post, 'https://api.cased.com/cli/sessions')
+          .to_return(
+            status: 200,
+            body: {
+              id: 'session_1234',
+              api_url: 'https://api.cased.com/cli/sessions/guard_session_1234',
+              api_record_url: 'https://api.cased.com/cli/sessions/guard_session_1234/record',
+              url: 'https://app.cased.com/cli/sessions/guard_session_1234',
+              state: 'requested',
+              reason: 'My reason',
+              ip_address: '1.1.1.1',
+              forwarded_ip_address: '127.0.0.1',
+              command: 'irb',
+              metadata: {
+                user_agent: 'iPhone',
+              },
+              requester: {
+                id: 'user_1234',
+              },
+              guard_application: {
+                id: 'guard_application_1234',
+              },
+            }.to_json,
+            headers: {
+              'Content-Type' => 'application/json',
+            },
+          )
+
+        stub_request(:get, 'https://api.cased.com/cli/sessions/guard_session_1234?user_token=user_1234')
+          .to_return(
+            status: 200,
+            body: {
+              id: 'session_1234',
+              api_url: 'https://api.cased.com/cli/sessions/guard_session_1234',
+              api_record_url: 'https://api.cased.com/cli/sessions/guard_session_1234/record',
+              url: 'https://app.cased.com/cli/sessions/guard_session_1234',
+              state: 'timed_out',
+              reason: 'My reason',
+              ip_address: '1.1.1.1',
+              forwarded_ip_address: '127.0.0.1',
+              command: 'irb',
+              metadata: {
+                user_agent: 'iPhone',
+              },
+              requester: {
+                id: 'user_1234',
+              },
+              guard_application: {
+                id: 'guard_application_1234',
+              },
+            }.to_json,
+            headers: {
+              'Content-Type' => 'application/json',
+            },
+          )
+
+        begin
+          Cased::CLI::InteractiveSession.start
+          assert false, 'did not expect this to be reached'
+        rescue SystemExit => error
+          assert true
+          assert_equal 1, error.status
+          assert_not error.success?
+        end
+      ensure
+        Cased.config.guard_user_token = old_guard_user_token
+      end
+    end
+  end
+end


### PR DESCRIPTION
If the request has timed out we want to exit the process right away. Also adds a regression test for the `timed_out` state, will add others in another PR.