### PR TITLE
Reverse merge metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Cased.configure do |config|
   # Attach metadata to all CLI requests. This metadata will appear in Cased and
   # any notification source such as email or Slack.
   #
-  # You are limited to 20 properties and cannot be a nested dictionary.
+  # You are limited to 20 properties and cannot be a nested dictionary. Metadata
+  # specified in the CLI request overrides any configured globally.
   config.cli.metadata = {
     rails_env: ENV['RAILS_ENV'],
     heroku_application: ENV['HEROKU_APP_NAME'],
@@ -210,6 +211,8 @@ Cased.configure do |config|
   }
 end
 ```
+
+Note: Metadata specified in the CLI request overrides any configured globally.
 
 ### Audit trails
 

--- a/lib/cased/cli/session.rb
+++ b/lib/cased/cli/session.rb
@@ -128,7 +128,7 @@ module Cased
         @authentication = authentication || Cased::CLI::Authentication.new
         @reason = reason
         @command = command || [$PROGRAM_NAME, *ARGV].join(' ')
-        @metadata = metadata.merge(Cased.config.cli.metadata)
+        @metadata = Cased.config.cli.metadata.merge(metadata)
         @requester = {}
         @responder = {}
         @guard_application = {}

--- a/test/lib/cased/cli/session_test.rb
+++ b/test/lib/cased/cli/session_test.rb
@@ -539,6 +539,21 @@ module Cased
       ensure
         Cased.config.cli.metadata = original_cli_metadata
       end
+
+      def test_metadata_specified_in_initializer_overrides_global
+        original_cli_metadata = Cased.config.cli.metadata
+        metadata = {
+          application: 'override',
+        }
+        Cased.config.cli.metadata = {
+          application: 'global',
+        }
+        session = Cased::CLI::Session.new(metadata: metadata)
+
+        assert_equal metadata, session.metadata
+      ensure
+        Cased.config.cli.metadata = original_cli_metadata
+      end
     end
   end
 end


### PR DESCRIPTION
Metadata specified globally should be overridden when metadata is specified directly on the CLI request.