### PR TITLE
Store original command for interactive sessions

### DIFF
--- a/lib/cased/cli/session.rb
+++ b/lib/cased/cli/session.rb
@@ -124,6 +124,12 @@ module Cased
       # @return [Hash, nil]
       attr_reader :guard_application
 
+      # Public: Cased may filter out sensitive data in the command, we shouldn't
+      # execute what is returned from the server.
+      #
+      # @return [String, nil]
+      attr_reader :original_command
+
       def initialize(reason: nil, command: nil, metadata: {}, authentication: nil)
         @authentication = authentication || Cased::CLI::Authentication.new
         @reason = reason
@@ -288,10 +294,6 @@ module Cased
       private
 
       attr_reader :error
-
-      # Cased may filter out sensitive data in the command, we shouldn't execute
-      # what is returned from the server.
-      attr_reader :original_command
     end
   end
 end

--- a/lib/cased/cli/session.rb
+++ b/lib/cased/cli/session.rb
@@ -127,7 +127,8 @@ module Cased
       def initialize(reason: nil, command: nil, metadata: {}, authentication: nil)
         @authentication = authentication || Cased::CLI::Authentication.new
         @reason = reason
-        @command = command || [$PROGRAM_NAME, *ARGV].join(' ')
+        @original_command = command || [$PROGRAM_NAME, *ARGV].join(' ')
+        @command = @original_command
         @metadata = Cased.config.cli.metadata.merge(metadata)
         @requester = {}
         @responder = {}
@@ -216,7 +217,7 @@ module Cased
 
         Cased::CLI::Log.log 'CLI session is now recording'
 
-        recorder = Cased::CLI::Recorder.new(command.split(' '), env: {
+        recorder = Cased::CLI::Recorder.new(original_command.split(' '), env: {
           'GUARD_SESSION_ID' => id,
           'GUARD_APPLICATION_ID' => guard_application.fetch('id'),
           'GUARD_USER_TOKEN' => requester.fetch('id'),
@@ -287,6 +288,10 @@ module Cased
       private
 
       attr_reader :error
+
+      # Cased may filter out sensitive data in the command, we shouldn't execute
+      # what is returned from the server.
+      attr_reader :original_command
     end
   end
 end


### PR DESCRIPTION
With our new [PII masking](https://docs.cased.com/docs/playback#masking-personally-identifiable-information-and-other-sensitive-data) for playback and other session metadata, before this change upon creating the session and getting approval, the command returned may include an interpolated string with sensitive data filtered out. For purposes of interactive sessions we need to keep a copy of the original command.