### PR TITLE
Correct all rubocop violations from rubocop upgrade

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -16,6 +16,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          gem install bundler
+          gem install bundler -v 2.2.27
           bundle install --local
       - run: bin/rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,8 @@ AllCops:
     - "bin/{rails,rake,bundle}"
     - "node_modules/**/*"
     - "app/views/**/*"
+  TargetRubyVersion: 2.5
+
 
 Style/Documentation:
   Enabled: false

--- a/cased-ruby.gemspec
+++ b/cased-ruby.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'activesupport', '~> 6.1'
   spec.add_dependency 'dotpath', '~> 0.1.0'

--- a/lib/cased.rb
+++ b/lib/cased.rb
@@ -20,7 +20,7 @@ require 'cased/cli'
 # Integrations
 begin
   require 'cased/integrations/sidekiq'
-rescue LoadError # rubocop:disable Lint/SuppressedException
+rescue LoadError
   # Sidekiq is not installed in host application
 end
 

--- a/lib/cased/cli/asciinema/file.rb
+++ b/lib/cased/cli/asciinema/file.rb
@@ -29,20 +29,10 @@ module Cased
         end
 
         # Required
-        attr_reader :header
-        attr_reader :version
-        attr_reader :width
-        attr_reader :height
-        attr_reader :stream
+        attr_reader :header, :version, :width, :height, :stream
 
         # Optional
-        attr_reader :timestamp
-        attr_reader :duration
-        attr_reader :idle_time_limit
-        attr_reader :command
-        attr_reader :title
-        attr_reader :env
-        attr_reader :theme
+        attr_reader :timestamp, :duration, :idle_time_limit, :command, :title, :env, :theme
 
         def initialize(header, stream)
           @header = header

--- a/lib/cased/cli/asciinema/writer.rb
+++ b/lib/cased/cli/asciinema/writer.rb
@@ -9,12 +9,8 @@ module Cased
       class Writer
         VERSION = 2
 
-        attr_accessor :width
-        attr_accessor :height
-        attr_reader :command
-        attr_reader :stream
-        attr_reader :started_at
-        attr_reader :finished_at
+        attr_accessor :width, :height
+        attr_reader :command, :stream, :started_at, :finished_at
 
         def initialize(command: [], width: 80, height: 24)
           @command = command

--- a/lib/cased/cli/authentication.rb
+++ b/lib/cased/cli/authentication.rb
@@ -5,8 +5,7 @@ require 'pathname'
 module Cased
   module CLI
     class Authentication
-      attr_reader :directory
-      attr_reader :credentials_path
+      attr_reader :directory, :credentials_path
       attr_writer :token
 
       def initialize(token: nil)

--- a/lib/cased/cli/log.rb
+++ b/lib/cased/cli/log.rb
@@ -14,10 +14,10 @@ module Cased
       def self.log(text)
         puts string(text)
       ensure
-        STDOUT.flush
+        $stdout.flush
       end
 
-      def self.color(text, color, bold = false)
+      def self.color(text, color, bold = false) # rubocop:disable Style/OptionalBooleanParameter
         color = self.class.const_get(color.upcase) if color.is_a?(Symbol)
         bold  = bold ? BOLD : ''
         "#{bold}#{color}#{text}#{CLEAR}"

--- a/lib/cased/cli/recorder.rb
+++ b/lib/cased/cli/recorder.rb
@@ -8,12 +8,7 @@ module Cased
       KEY = 'CASED_CLI_RECORDING'
       TRUE = '1'
 
-      attr_reader :command
-      attr_reader :events
-      attr_reader :started_at
-      attr_reader :width
-      attr_reader :height
-      attr_reader :options
+      attr_reader :command, :events, :started_at, :width, :height, :options
       attr_accessor :writer
 
       # @return [Boolean] if CLI session is being recorded.
@@ -46,7 +41,7 @@ module Cased
         writer.time do
           Subprocess.check_call(command, options) do |t|
             t.communicate do |stdout, _stderr|
-              STDOUT.write(stdout)
+              $stdout.write(stdout)
 
               writer << stdout.gsub("\n", "\r\n")
             end

--- a/lib/cased/cli/session.rb
+++ b/lib/cased/cli/session.rb
@@ -288,7 +288,7 @@ module Cased
       end
 
       def recordable?
-        STDOUT.isatty
+        $stdout.isatty
       end
 
       private

--- a/lib/cased/http/error.rb
+++ b/lib/cased/http/error.rb
@@ -6,8 +6,7 @@ require 'json'
 module Cased
   module HTTP
     class Error < Cased::Error
-      attr_reader :code
-      attr_reader :json
+      attr_reader :code, :json
 
       def initialize(json = {}, code = nil)
         @json = json

--- a/lib/cased/policy.rb
+++ b/lib/cased/policy.rb
@@ -4,8 +4,7 @@ require 'cased/query'
 
 module Cased
   class Policy
-    attr_reader :api_key
-    attr_reader :client
+    attr_reader :api_key, :client
 
     def initialize(api_key:)
       @api_key = api_key

--- a/lib/cased/publishers/test_publisher.rb
+++ b/lib/cased/publishers/test_publisher.rb
@@ -8,6 +8,7 @@ module Cased
       attr_reader :events
 
       def initialize
+        super
         @events = []
       end
 

--- a/lib/cased/response.rb
+++ b/lib/cased/response.rb
@@ -2,8 +2,7 @@
 
 module Cased
   class Response
-    attr_reader :body
-    attr_reader :exception
+    attr_reader :body, :exception
 
     def initialize(response: nil, exception: nil)
       @response = response

--- a/lib/cased/sensitive/processor.rb
+++ b/lib/cased/sensitive/processor.rb
@@ -21,8 +21,7 @@ module Cased
         }
       end
 
-      attr_reader :audit_event
-      attr_reader :handlers
+      attr_reader :audit_event, :handlers
 
       def initialize(audit_event, handlers)
         @audit_event = audit_event.dup.freeze

--- a/lib/cased/sensitive/range.rb
+++ b/lib/cased/sensitive/range.rb
@@ -20,7 +20,7 @@ module Cased
       # Public: The end offset of the sensitive value in the original value.
       attr_reader :end_offset
 
-      def initialize(label: nil, key:, begin_offset:, end_offset:, identifier: nil)
+      def initialize(key:, begin_offset:, end_offset:, label: nil, identifier: nil)
         raise ArgumentError, 'missing key' if key.nil?
         raise ArgumentError, 'missing begin_offset' if begin_offset.nil?
         raise ArgumentError, 'missing end_offset' if end_offset.nil?

--- a/lib/cased/sensitive/string.rb
+++ b/lib/cased/sensitive/string.rb
@@ -5,8 +5,7 @@ require 'cased/sensitive/range'
 module Cased
   module Sensitive
     class String < String
-      attr_reader :label
-      attr_reader :string
+      attr_reader :label, :string
 
       def initialize(string, label: nil)
         super(string)

--- a/test/cased_test.rb
+++ b/test/cased_test.rb
@@ -111,7 +111,7 @@ class CasedTest < Cased::Test
     test_publisher = Cased::Publishers::TestPublisher.new
     Cased.publishers = [test_publisher]
 
-    Cased.sensitive(:phone_number, /\d{3}\-\d{3}\-\d{4}/)
+    Cased.sensitive(:phone_number, /\d{3}-\d{3}-\d{4}/)
 
     travel_to(Time.utc(2020, 1, 1)) do
       Cased.publish(action: 'user.login', body: 'Hello 111-222-3333')
@@ -144,7 +144,7 @@ class CasedTest < Cased::Test
 
   def test_registering_sensitive_handler
     assert_difference 'Cased::Sensitive::Handler.handlers.length' do
-      Cased.sensitive(:username, /\@\w+/)
+      Cased.sensitive(:username, /@\w+/)
     end
   end
 

--- a/test/lib/cased/sensitive/processor_test.rb
+++ b/test/lib/cased/sensitive/processor_test.rb
@@ -25,7 +25,7 @@ module Cased
       def test_processes_audit_event_with_global_handlers
         old_handlers = Cased::Sensitive::Handler.handlers
         Cased::Sensitive::Handler.handlers = []
-        Cased::Sensitive::Handler.register(:phone_number, /\d{3}\-\d{3}\-\d{4}/)
+        Cased::Sensitive::Handler.register(:phone_number, /\d{3}-\d{3}-\d{4}/)
         result = Cased::Sensitive::Processor.process(action: 'Hello 111-222-3333')
 
         expected_result = {
@@ -46,7 +46,7 @@ module Cased
       def test_processes_nested_audit_event_with_global_handlers
         old_handlers = Cased::Sensitive::Handler.handlers
         Cased::Sensitive::Handler.handlers = []
-        Cased::Sensitive::Handler.register(:phone_number, /\d{3}\-\d{3}\-\d{4}/)
+        Cased::Sensitive::Handler.register(:phone_number, /\d{3}-\d{3}-\d{4}/)
         result = Cased::Sensitive::Processor.process(
           action: 'Hello 111-222-3333',
           users: [
@@ -82,7 +82,7 @@ module Cased
       def test_mutates_audit_event_if_using_bang_method
         old_handlers = Cased::Sensitive::Handler.handlers
         Cased::Sensitive::Handler.handlers = []
-        Cased::Sensitive::Handler.register(:phone_number, /\d{3}\-\d{3}\-\d{4}/)
+        Cased::Sensitive::Handler.register(:phone_number, /\d{3}-\d{3}-\d{4}/)
         audit_event = {
           body: 'Hello 111-222-3333',
         }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,15 +22,15 @@ module Cased
     end
 
     def suppress_output
-      original_stderr = STDERR.clone
-      original_stdout = STDOUT.clone
-      STDERR.reopen(File.new('/dev/null', 'w'))
-      STDOUT.reopen(File.new('/dev/null', 'w'))
+      original_stderr = $stderr.clone
+      original_stdout = $stdout.clone
+      $stderr.reopen(File.new('/dev/null', 'w'))
+      $stdout.reopen(File.new('/dev/null', 'w'))
 
       yield
     ensure
-      STDERR.reopen(original_stderr)
-      STDOUT.reopen(original_stdout)
+      $stderr.reopen(original_stderr)
+      $stdout.reopen(original_stdout)
     end
   end
 end


### PR DESCRIPTION
Fixes rubocop violations from the upgrade to Ruby 3.0. Since the gem is
tested down to Ruby 2.5, updates the target version to that and updates
rubocop to match.

The majority of these changes are autofixes. The fixes for the `Style/GlobalStdStream`
cop are potentially "unsafe" according to rubocop and required the `-A` (capitalized) to
fix them.

The manual fixes were:
- adjusting the ruby version to match the lowest version tested
- disabling the `Style/OptionalBooleanParameter` check which would alter a method signature
- adding `super` in TestPublisher, which should be fine since it doesn't look like the parent does anything in initialize